### PR TITLE
Bcp 549

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>ca.bc.gov.bcparis</groupId>
 	<artifactId>bcparis-service</artifactId>
 	<name>BCPARIS Legacy Migration</name>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.0.0</version>
 
 	<parent>
 		<groupId>ca.bc.gov.iamp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>ca.bc.gov.bcparis</groupId>
 	<artifactId>bcparis-service</artifactId>
 	<name>BCPARIS Legacy Migration</name>
-	<version>1.0.0</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<parent>
 		<groupId>ca.bc.gov.iamp</groupId>

--- a/src/main/java/ca/bc/gov/iamp/bcparis/repository/ICBCRestRepository.java
+++ b/src/main/java/ca/bc/gov/iamp/bcparis/repository/ICBCRestRepository.java
@@ -23,65 +23,74 @@ import ca.bc.gov.iamp.bcparis.repository.rest.BaseRest;
 @Repository
 public class ICBCRestRepository extends BaseRest {
 
-	private final Logger log = LoggerFactory.getLogger(ICBCRestRepository.class);
+    private final Logger log = LoggerFactory.getLogger(ICBCRestRepository.class);
 
-	@Value("${endpoint.icbc.rest}")
-	private String icbcUrl;
+    @Value("${endpoint.icbc.rest}")
+    private String icbcUrl;
 
-	@Value("${endpoint.icbc.rest.header.imsUserId}")
-	private String imsUserId;
+    @Value("${endpoint.icbc.rest.header.imsUserId}")
+    private String imsUserId;
 
-	@Value("${endpoint.icbc.rest.header.imsCredential}")
-	private String imsCredential;
+    @Value("${endpoint.icbc.rest.header.imsCredential}")
+    private String imsCredential;
 
-	@Value("${endpoint.icbc.rest.path.transaction}")
-	private String pathTransaction;
+    @Value("${endpoint.icbc.rest.path.transaction}")
+    private String pathTransaction;
 
-	@Value("${endpoint.icbc.rest.header.username}")
-	private String username;
+    @Value("${endpoint.icbc.rest.header.username}")
+    private String username;
 
-	@Value("${endpoint.icbc.rest.header.password}")
-	private String password;
+    @Value("${endpoint.icbc.rest.header.password}")
+    private String password;
 
-	@NewSpan("icbc")
-	public String requestDetails(final Layer7Message l7message, IMSRequest ims) {
-		try {
-			final String URL = icbcUrl + pathTransaction;
-			log.debug(String.format("Calling ICBC Rest Service. URL=%s, IMS=%s", URL, ims.imsRequest ));
-			
-			HttpEntity<?> httpEntity = new HttpEntity<IMSRequest>(ims,  getHeaders(l7message, username, password));
-			
-			ResponseEntity<IMSResponse> response = getRestTemplate().postForEntity(URL, httpEntity, IMSResponse.class);
-			
-			assertResponse(HttpStatus.OK, response.getStatusCode(), response.getBody().toString() );
-			
-			return response.getBody().getImsResponse();
-		}catch (HttpServerErrorException e) {
-			throw new ICBCRestException(
-				String.format("Message=%s\n Response Body=%s", e.getLocalizedMessage(), e.getResponseBodyAsString()),
-				e.getResponseBodyAsString(), e);
-		}
-		catch (Exception e) {
-			throw new ICBCRestException(
-				String.format("Message=%s", e.getLocalizedMessage()), 
-				e.getLocalizedMessage(), e);
-		}
-	}
+    @NewSpan("icbc")
+    public String requestDetails(final Layer7Message l7message, IMSRequest ims) {
+        try {
+            final String URL = icbcUrl + pathTransaction;
+            log.debug(String.format("Calling ICBC Rest Service. URL=%s, IMS=%s", URL, ims.imsRequest));
 
-	private HttpHeaders getHeaders(final Layer7Message l7message, final String username, final String password) {
-		HttpHeaders headers = getHeadersWithBasicAuth(username, password);
-		headers.add("imsUserId", imsUserId);
-		headers.add("imsCredential", imsCredential);
-		headers.add("auditTransactionId", generateAuditTransactionId(l7message));
-		return headers;
-	}
-	
-	private String generateAuditTransactionId(final Layer7Message l7message){
-		if(l7message != null && l7message.getEnvelope() != null  && l7message.getEnvelope().getMqmd() != null){
-			MQMD mqmd = l7message.getEnvelope().getMqmd();
-			return String.format("[messageIdByte:%s | correlationIdByte:%s] ", mqmd.getMessageIdByte(), mqmd.getCorrelationIdByte());
-		}
-		return UUID.randomUUID().toString();
-	}
+            HttpEntity<?> httpEntity = new HttpEntity<IMSRequest>(ims, getHeaders(l7message, username, password));
+
+            ResponseEntity<IMSResponse> response = getRestTemplate().postForEntity(URL, httpEntity, IMSResponse.class);
+
+            assertResponse(HttpStatus.OK, response.getStatusCode(), response.getBody().toString());
+
+            return response.getBody().getImsResponse();
+        } catch (HttpServerErrorException e) {
+            throw new ICBCRestException(
+                    String.format("Message=%s\n Response Body=%s", e.getLocalizedMessage(), e.getResponseBodyAsString()),
+                    e.getResponseBodyAsString(), e);
+        } catch (Exception e) {
+            throw new ICBCRestException(
+                    String.format("Message=%s", e.getLocalizedMessage()),
+                    e.getLocalizedMessage(), e);
+        }
+    }
+
+    public HttpHeaders getHeaders(final Layer7Message l7message, final String username, final String password) {
+        HttpHeaders headers = getHeadersWithBasicAuth(username, password);
+        headers.add("imsUserId", imsUserId);
+        headers.add("imsCredential", imsCredential);
+        headers.add("auditTransactionId", generateAuditTransactionId(l7message));
+        return headers;
+    }
+
+    private String generateAuditTransactionId(final Layer7Message l7message) {
+
+        if (l7message != null && l7message.getEnvelope() != null && l7message.getEnvelope().getMqmd() != null) {
+            MQMD mqmd = l7message.getEnvelope().getMqmd();
+            String messageIdByte = mqmd.getMessageIdByte();
+            String correlationIdByte = mqmd.getCorrelationIdByte();
+            if (messageIdByte != null && !messageIdByte.isEmpty()) {
+                messageIdByte = messageIdByte.replaceAll("\\s+", "");
+                return messageIdByte;
+            } else if(correlationIdByte !=null && !correlationIdByte.isEmpty()) {
+                correlationIdByte = correlationIdByte.replaceAll("\\s+", "");
+                return correlationIdByte;
+            }
+
+        }
+        return UUID.randomUUID().toString();
+    }
 
 }

--- a/src/test/java/ca/bc/gov/iamp/bcparis/repository/ICBCRestRepositoryTest.java
+++ b/src/test/java/ca/bc/gov/iamp/bcparis/repository/ICBCRestRepositoryTest.java
@@ -1,5 +1,12 @@
 package ca.bc.gov.iamp.bcparis.repository;
 
+import ca.bc.gov.iamp.bcparis.model.message.Envelope;
+import ca.bc.gov.iamp.bcparis.model.message.body.Body;
+import ca.bc.gov.iamp.bcparis.model.message.body.MQMD;
+import ca.bc.gov.iamp.bcparis.model.message.header.Header;
+import ca.bc.gov.iamp.bcparis.model.message.header.MsgSrvc;
+import ca.bc.gov.iamp.bcparis.model.message.header.Origin;
+import ca.bc.gov.iamp.bcparis.model.message.header.Routing;
 import org.aspectj.bridge.MessageUtil;
 import org.junit.Assert;
 import org.junit.Before;
@@ -10,6 +17,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.internal.util.reflection.FieldSetter;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpServerErrorException;
@@ -42,18 +50,47 @@ public class ICBCRestRepositoryTest {
 
         Mockito.when(rest.postForEntity(Mockito.anyString(), Mockito.any(HttpEntity.class), Mockito.any()) )
     		.thenReturn(new ResponseEntity<>(getResponse(), HttpStatus.OK));
-		
+
 		final String icbcResponse = repo.requestDetails(BCPARISTestUtil.getMessageDriverDL(), IMSRequest.builder().build());
 		
 		Assert.assertEquals(icbcResponse, "IMS Response");
 	}
-	
+	@Test
+	public void request_details_mqmd_messageId() {
+
+		Mockito.when(rest.postForEntity(Mockito.anyString(), Mockito.any(HttpEntity.class), Mockito.any()) )
+				.thenReturn(new ResponseEntity<>(getResponse(), HttpStatus.OK));
+		Layer7Message message = createLayer7Message_withMessageId();
+		HttpHeaders results = repo.getHeaders(message,"username","password");
+
+		Assert.assertEquals("414D5120434251332020202020202020D9BF035D85206E23", results.get("auditTransactionId").get(0));
+	}
+	@Test
+	public void request_details_mqmd_correlationId() {
+
+		Mockito.when(rest.postForEntity(Mockito.anyString(), Mockito.any(HttpEntity.class), Mockito.any()) )
+				.thenReturn(new ResponseEntity<>(getResponse(), HttpStatus.OK));
+		Layer7Message message = createLayer7Message_withCorrelationId();
+		HttpHeaders results = repo.getHeaders(message,"username","password");
+
+		Assert.assertEquals("414D5120424D565133564943202020205D0AD28120386102", results.get("auditTransactionId").get(0));
+			}
+	@Test
+	public void request_details_no_auditTransactionId() {
+
+		Mockito.when(rest.postForEntity(Mockito.anyString(), Mockito.any(HttpEntity.class), Mockito.any()) )
+				.thenReturn(new ResponseEntity<>(getResponse(), HttpStatus.OK));
+		Layer7Message message = createLayer7Message_noAuditTransactionId();
+		HttpHeaders results = repo.getHeaders(message,"username","password");
+
+		Assert.assertNotNull(results.get("auditTransactionId"));
+	}
 	@Test(expected=ICBCRestException.class)
 	public void request_details_rest_exception() {
 
         Mockito.when(rest.postForEntity(Mockito.anyString(), Mockito.any(HttpEntity.class), Mockito.any()) )
     		.thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"));
-		
+
 		repo.requestDetails(BCPARISTestUtil.getMessageDriverDL(), IMSRequest.builder().build());
 	}
 	
@@ -71,5 +108,106 @@ public class ICBCRestRepositoryTest {
 				.imsResponse("IMS Response")
 				.build();
 	}
-	
+
+	private Layer7Message createLayer7Message_withMessageId() {
+		 String NEW_LINE = "\n";
+		 String cdata = "SEND MT:M" + NEW_LINE +
+				"FMT:Y" + NEW_LINE +
+				"FROM:{FROM}" + NEW_LINE +
+				"TO:{TO}" + NEW_LINE +
+				"TEXT:{TEXT}" + NEW_LINE +
+				NEW_LINE +
+				"{QUERY_MESSAGE}" +
+				NEW_LINE + NEW_LINE +
+				"{DATE_TIME}{DATE_TIME}";
+
+		Header header = Header.builder()
+				.role("ROLE 1")
+				.origin(Origin.builder().qname("CPIC.MSG.AGENCY.REMOTE").qMgrName("BMVQ3VIC").build())
+				.agencyId("AGENCY 1")
+				.cpicVer("1.4")
+				.userId("UID 1")
+				.deviceId("DEVICE ID 1")
+				.udf("BCPARISTEST")
+				.priority("1")
+				.routing(Routing.builder().qname("CPIC.MSG.BMVQ3VIC").qMgrName("BMVQ3VIC").build())
+				.msgSrvc(MsgSrvc.builder().msgActn("Send").build())
+				.build();
+
+		Envelope envelope = Envelope.builder()
+				.header(header)
+				.body( Body.builder().msgFFmt(cdata).build() )
+				.mqmd( MQMD.builder().messageIdByte("41 4D 51 20 43 42 51 33 20 20 20 20 20 20 20 20 D9 BF 03 5D 85 20 6E 23").correlationIdByte("41 4D 51 20 42 4D 56 51 33 56 49 43 20 20 20 20 5D 0A D2 81 20 38 61 02").build())
+				.build();
+
+		return Layer7Message.builder().envelope(envelope).build();
+	}
+
+	private Layer7Message createLayer7Message_withCorrelationId() {
+		String NEW_LINE = "\n";
+		String cdata = "SEND MT:M" + NEW_LINE +
+				"FMT:Y" + NEW_LINE +
+				"FROM:{FROM}" + NEW_LINE +
+				"TO:{TO}" + NEW_LINE +
+				"TEXT:{TEXT}" + NEW_LINE +
+				NEW_LINE +
+				"{QUERY_MESSAGE}" +
+				NEW_LINE + NEW_LINE +
+				"{DATE_TIME}{DATE_TIME}";
+
+		Header header = Header.builder()
+				.role("ROLE 1")
+				.origin(Origin.builder().qname("CPIC.MSG.AGENCY.REMOTE").qMgrName("BMVQ3VIC").build())
+				.agencyId("AGENCY 1")
+				.cpicVer("1.4")
+				.userId("UID 1")
+				.deviceId("DEVICE ID 1")
+				.udf("BCPARISTEST")
+				.priority("1")
+				.routing(Routing.builder().qname("CPIC.MSG.BMVQ3VIC").qMgrName("BMVQ3VIC").build())
+				.msgSrvc(MsgSrvc.builder().msgActn("Send").build())
+				.build();
+
+		Envelope envelope = Envelope.builder()
+				.header(header)
+				.body( Body.builder().msgFFmt(cdata).build() )
+				.mqmd( MQMD.builder().correlationIdByte("41 4D 51 20 42 4D 56 51 33 56 49 43 20 20 20 20 5D 0A D2 81 20 38 61 02").build())
+				.build();
+
+		return Layer7Message.builder().envelope(envelope).build();
+	}
+
+	private Layer7Message createLayer7Message_noAuditTransactionId() {
+		String NEW_LINE = "\n";
+		String cdata = "SEND MT:M" + NEW_LINE +
+				"FMT:Y" + NEW_LINE +
+				"FROM:{FROM}" + NEW_LINE +
+				"TO:{TO}" + NEW_LINE +
+				"TEXT:{TEXT}" + NEW_LINE +
+				NEW_LINE +
+				"{QUERY_MESSAGE}" +
+				NEW_LINE + NEW_LINE +
+				"{DATE_TIME}{DATE_TIME}";
+
+		Header header = Header.builder()
+				.role("ROLE 1")
+				.origin(Origin.builder().qname("CPIC.MSG.AGENCY.REMOTE").qMgrName("BMVQ3VIC").build())
+				.agencyId("AGENCY 1")
+				.cpicVer("1.4")
+				.userId("UID 1")
+				.deviceId("DEVICE ID 1")
+				.udf("BCPARISTEST")
+				.priority("1")
+				.routing(Routing.builder().qname("CPIC.MSG.BMVQ3VIC").qMgrName("BMVQ3VIC").build())
+				.msgSrvc(MsgSrvc.builder().msgActn("Send").build())
+				.build();
+
+		Envelope envelope = Envelope.builder()
+				.header(header)
+				.body( Body.builder().msgFFmt(cdata).build() )
+				.mqmd( MQMD.builder().build())
+				.build();
+
+		return Layer7Message.builder().envelope(envelope).build();
+	}
 }


### PR DESCRIPTION
This is fix for the ticket https://justice.gov.bc.ca/jira/browse/BCP-549 .The code now send only messageID or the correlationID, not both when it queries ICBC.vIt removes the whitespace from the id before sending it . 
3 testcases added to test the new code changes