### PR TITLE
updated commons to match version with updated spring/tomcat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>ca.bc.gov.iamp</groupId>
 		<artifactId>spring-boot-api-service</artifactId>
-		<version>1.0.2</version>
+		<version>1.1.0</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Upgrade the pom file of bcparis-service to point at the correct version of iamp-commons artifact.